### PR TITLE
WEB-84: training form marketing consent

### DIFF
--- a/_sass/_styles.scss
+++ b/_sass/_styles.scss
@@ -462,6 +462,76 @@ footer {
 
 
     }
+
+    // GDPR Checkbox CSS
+    .gdpr {
+        label {
+            display: block;
+            position: relative;
+            padding-left: 35px;
+            margin: 20px auto;
+            cursor: pointer;
+            font-size: 14px;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+        }
+
+        label:nth-of-type(even) {
+            margin-bottom: 45px;
+        }
+
+        label input {
+            position: absolute;
+            opacity: 0;
+            cursor: pointer;
+        }
+
+        .checkmark {
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 20px;
+            width: 20px;
+            padding-bottom: 0;
+            border: 1px solid $medium-gray;
+            background-color: $lightest-gray;
+        }
+
+        label:hover input ~ .checkmark {
+            background-color: $light-gray;
+        }
+
+        label input:checked ~ .checkmark {
+            background-color: $green;
+            padding-bottom: 0;
+        }
+
+        .checkmark:after {
+            content: "";
+            position: absolute;
+            display: none;
+        }
+
+        label input:checked ~ .checkmark:after {
+            display: block;
+        }
+
+        // checkmark/indicator
+        label .checkmark:after {
+            left: 6px;
+            top: 2px;
+            width: 5px;
+            height: 10px;
+            border: solid #ffffff;
+            border-width: 0 3px 3px 0;
+            -webkit-transform: rotate(45deg);
+            -ms-transform: rotate(45deg);
+            transform: rotate(45deg);
+        }
+    }
+
     .saveForm {
         display: block;
         background: $purple;

--- a/assets/js/form.js
+++ b/assets/js/form.js
@@ -17,7 +17,7 @@ $( document ).ready(function() {
         scrapy_expertise: "required",
         webscraping_expertise: "required",
         htmlcss_expertise: "required",
-        privacy_policy: "required",
+        "privacy-policy": "required",
       }
     });
 

--- a/assets/js/form.js
+++ b/assets/js/form.js
@@ -17,6 +17,7 @@ $( document ).ready(function() {
         scrapy_expertise: "required",
         webscraping_expertise: "required",
         htmlcss_expertise: "required",
+        privacy_policy: "required",
       }
     });
 

--- a/request.html
+++ b/request.html
@@ -132,6 +132,18 @@ custom_js_files:
                         <small>Please provide any further details about your team and specific needs you might have with this training.</small>
                     </div>
 
+                    <div class="gdpr">
+                        <label>Yes! I would like to receive email updates from Scrapinghub on products, news, events, and offers.
+                            <input type="checkbox" id="marketing_emails" name="marketing_emails">
+                            <span class="checkmark"></span>
+                        </label>
+
+                        <label>I have read and agree to Scrapinghub's <a href="{{ site.url }}/privacy-policy">Privacy Policy</a> and <a href="{{ site.url }}/cookie-policy">Cookie Policy</a>.
+                            <input type="checkbox" id="privacy_policy" name="privacy_policy">
+                            <span class="checkmark"></span>
+                        </label>
+                    </div>
+
                     <input type="submit" class="saveForm" value="Schedule a training">
                 </form>
             </div>

--- a/request.html
+++ b/request.html
@@ -139,7 +139,7 @@ custom_js_files:
                         </label>
 
                         <label>I have read and agree to Scrapinghub's <a href="{{ site.url }}/privacy-policy">Privacy Policy</a> and <a href="{{ site.url }}/cookie-policy">Cookie Policy</a>.
-                            <input type="checkbox" id="privacy_policy" name="privacy_policy">
+                            <input type="checkbox" id="privacy-policy" name="privacy-policy">
                             <span class="checkmark"></span>
                         </label>
                     </div>


### PR DESCRIPTION
- used underscores instead of dashes `<input type="checkbox" id="privacy_policy" name="privacy_policy">`